### PR TITLE
Implemented vector module

### DIFF
--- a/gtFrame/basic.py
+++ b/gtFrame/basic.py
@@ -64,6 +64,36 @@ class RootFrame2d:
 
         return path[::-1]      # path is generated in reverse
 
+    def transform_from(self, frame, vector):
+        """
+        Transform a vector expressed in an arbitrary frame of reference into
+        this frame.
+
+        :param frame: the frame of reference, in which the vector is defined
+        :type frame: Frame2d
+        :param vector: the vector to be transformed
+        :type vector: np.ndarray
+        :return: the transformed vector
+        :rtype: np.ndarray
+        """
+        path = frame.find_transform_path(self)
+        return Frame2d.transform_via_path(vector, path)
+
+    def transform_to(self, frame, vector):
+        """
+        Transform a vector expressed in this frame of reference into a given
+        frame of reference.
+
+        :param frame: the frame to which to transform to
+        :type frame: Frame2d
+        :param vector: the vector to be transformed
+        :type vector: np.ndarray
+        :return: the transformed vector
+        :rtype: np.ndarray
+        """
+        path = self.find_transform_path(frame)
+        return Frame2d.transform_via_path(vector, path)
+
 
 # Module variables
 origin2d = RootFrame2d()
@@ -365,6 +395,36 @@ class RootFrame3d:
             current_frame = current_frame.parent()
 
         return path[::-1]      # path is generated in reverse
+
+    def transform_from(self, frame, vector):
+        """
+        Transform a vector expressed in an arbitrary frame of reference into
+        this frame.
+
+        :param frame: the frame of reference, in which the vector is defined
+        :type frame: Frame3d
+        :param vector: the vector to be transformed
+        :type vector: np.ndarray
+        :return: the transformed vector
+        :rtype: np.ndarray
+        """
+        path = frame.find_transform_path(self)
+        return Frame3d.transform_via_path(vector, path)
+
+    def transform_to(self, frame, vector):
+        """
+        Transform a vector expressed in this frame of reference into a given
+        frame of reference.
+
+        :param frame: the frame to which to transform to
+        :type frame: Frame3d
+        :param vector: the vector to be transformed
+        :type vector: np.ndarray
+        :return: the transformed vector
+        :rtype: np.ndarray
+        """
+        path = self.find_transform_path(frame)
+        return Frame3d.transform_via_path(vector, path)
 
 
 origin3d = RootFrame3d()

--- a/gtFrame/basic.py
+++ b/gtFrame/basic.py
@@ -34,6 +34,18 @@ class RootFrame2d:
         self.position = np.array([0, 0], dtype=np.float64)
         self.rotation = gtFrame.rotation.Rotation2d(0)
 
+    def find_common_parent(self, frame):
+        """
+        Finds the nearest common parent of this frame and a given frame. Since
+        this is a RootFrame2d it will always return itself.
+
+        :param frame: other frame
+        :type frame: gtFrame.basic.Frame2d
+        :return: the nearest common parent, which is always self
+        :rtype: gtFrame.basic.RootFrame2d
+        """
+        return self
+
     def find_transform_path(self, frame):
         """
         Finds the transform path from this frame of reference to the given
@@ -81,6 +93,42 @@ class Frame2d:
         self.position = position.copy()
         self.rotation = rotation
         self._parent = parent_frame
+
+    def find_common_parent(self, frame):
+        """
+        Finds the nearest common parent of this frame and a given frame.
+
+        :param frame: other frame
+        :type frame: gtFrame.basic.Frame2d
+        :return: the nearest common parent frame
+        :rtype: gtFrame.basic.Frame2d
+        """
+        # return frame if frame is root frame
+        if type(frame).__name__ == 'RootFrame2d':
+            return frame
+
+        # find path from self to origin
+        current_frame = self
+        path_self = list()
+
+        while type(current_frame).__name__ != 'RootFrame2d':
+            path_self.append(current_frame)
+            current_frame = current_frame.parent()
+
+        # find path from frame to origin
+        current_frame = frame
+        path_foreign = list()
+
+        while type(current_frame).__name__ != 'RootFrame2d':
+            path_foreign.append(current_frame)
+            current_frame = current_frame.parent()
+
+        for frame in path_self:
+            if frame in path_foreign:
+                return frame
+
+        # default: return root-frame (if there is no common parent)
+        return path_self[-1].parent()
 
     def find_transform_path_legacy(self, frame):
         """
@@ -287,6 +335,18 @@ class RootFrame3d:
                                                         [0, 0, 0],
                                                         dtype=np.float64))
 
+    def find_common_parent(self, frame):
+        """
+        Finds the nearest common parent of this frame and a given frame. Since
+        this is a RootFrame3d it will always return itself.
+
+        :param frame: other frame
+        :type frame: gtFrame.basic.Frame3d
+        :return: the nearest common parent, which is always self
+        :rtype: gtFrame.basic.RootFrame3d
+        """
+        return self
+
     def find_transform_path(self, frame):
         """
         Finds the transform path from this frame of reference to the given
@@ -330,6 +390,42 @@ class Frame3d:
         self.position = position.copy()
         self.rotation = rotation
         self._parent = parent_frame
+
+    def find_common_parent(self, frame):
+        """
+        Finds the nearest common parent of this frame and a given frame.
+
+        :param frame: other frame
+        :type frame: gtFrame.basic.Frame3d
+        :return: the nearest common parent frame
+        :rtype: gtFrame.basic.Frame3d
+        """
+        # return frame if frame is root frame
+        if type(frame).__name__ == 'RootFrame3d':
+            return frame
+
+        # find path from self to origin
+        current_frame = self
+        path_self = list()
+
+        while type(current_frame).__name__ != 'RootFrame3d':
+            path_self.append(current_frame)
+            current_frame = current_frame.parent()
+
+        # find path from frame to origin
+        current_frame = frame
+        path_foreign = list()
+
+        while type(current_frame).__name__ != 'RootFrame3d':
+            path_foreign.append(current_frame)
+            current_frame = current_frame.parent()
+
+        for frame in path_self:
+            if frame in path_foreign:
+                return frame
+
+        # default: return root-frame (if there is no common parent)
+        return path_self[-1].parent()
 
     def find_transform_path_legacy(self, frame):
         """

--- a/gtFrame/basic.py
+++ b/gtFrame/basic.py
@@ -229,7 +229,8 @@ class Frame2d:
         # optimisations: cut out all occurrences of two same frames
         for i, node in enumerate(path):
             for j, node_secondary in enumerate(path[i:]):
-                if node_secondary[0] == node[0] and node_secondary[1] != node[1]:
+                if node_secondary[0] == node[0] and \
+                        node_secondary[1] != node[1]:
                     del path[i:i+j+1]
                     break
 
@@ -525,7 +526,8 @@ class Frame3d:
         # optimisations: cut out all occurrences of two same frames
         for i, node in enumerate(path):
             for j, node_secondary in enumerate(path[i:]):
-                if node_secondary[0] == node[0] and node_secondary[1] != node[1]:
+                if node_secondary[0] == node[0] and \
+                        node_secondary[1] != node[1]:
                     del path[i:i + j + 1]
                     break
 

--- a/gtFrame/vector.py
+++ b/gtFrame/vector.py
@@ -1,0 +1,31 @@
+"""
+The :mod:`gtFrame.vector` module implements vectors (2d and 3d) which
+automatically detect frames of reference and convert to a common base.
+
+---------------
+Module Contents
+---------------
+
+Classes:
+    * Vector2d
+    * Vector3d
+
+"""
+
+
+class Vector2d:
+    """
+    Acts as a 2d Vector and converts to appropriate frames of references when
+    performing operations.
+
+    :param reference: the reference in which the vector is defined
+    :type reference: gtFrame.basic.Frame2d
+    :param coordinates: the vector coordinates in the defined reference
+    :type coordinates: np.ndarray
+    """
+    def __init__(self, reference, coordinates):
+        """
+        Constructor method.
+        """
+        self.reference = reference
+        self.coordinates = coordinates

--- a/gtFrame/vector.py
+++ b/gtFrame/vector.py
@@ -29,3 +29,14 @@ class Vector2d:
         """
         self.reference = reference
         self.coordinates = coordinates
+
+    def transform_to(self, reference):
+        """
+        Returns the representation (i.e. the coordinates) of the vector in a
+        different frame of reference
+        :param reference: the reference to convert to
+        :type reference: gtFrame.basic.Frame2d
+        :return: coordinates in the 'reference' frame of reference
+        :rtype: np.ndarray
+        """
+        return self.reference.transform_to(reference, self.coordinates)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -202,6 +202,70 @@ class TestRootFrame2d:
         assert expected6 == origin2d.find_transform_path(frame6)
         assert expected7 == origin2d.find_transform_path(frame7)
 
+    def test_transform_from(self, frame2d_system):
+        """
+        Test the .transform_from method with random vectors and random paths.
+
+        :return: None
+        """
+        vectors = [np.random.random(2) for _ in range(10)]
+
+        for vector in vectors:
+            vector_copy = vector.copy()
+            source = frame2d_system[random.randint(0, 6)]
+            destination = origin2d
+
+            # calculate expected
+            path = source.find_transform_path(destination)
+            expected = Frame2d.transform_via_path(vector, path)
+
+            assert np.allclose(destination.transform_from(source, vector),
+                               expected, rtol=RTOL)
+
+            # Check that vector didn't change
+            assert np.allclose(vector, vector_copy, rtol=RTOL)
+
+    def test_transform_to(self, frame2d_system):
+        """
+        Test the .transform_to method with random vectors and random paths.
+
+        :return: None
+        """
+        vectors = [np.random.random(2) for _ in range(10)]
+
+        for vector in vectors:
+            vector_copy = vector.copy()
+            source = origin2d
+            destination = frame2d_system[random.randint(0, 6)]
+
+            # calculate expected
+            path = source.find_transform_path(destination)
+            expected = Frame2d.transform_via_path(vector, path)
+
+            assert np.allclose(source.transform_to(destination, vector),
+                               expected, rtol=RTOL)
+
+            # Check that vector didn't change
+            assert np.allclose(vector, vector_copy, rtol=RTOL)
+
+    def test_transform_reversible(self, frame2d_system):
+        """
+        Test wether the .transform_to and transform_from methods are
+        reversible.
+
+        :return: None
+        """
+        vectors = [np.random.random(2) for _ in range(10)]
+
+        for vector in vectors:
+            source = origin2d
+            destination = frame2d_system[random.randint(0, 6)]
+
+            interim = source.transform_to(destination, vector)
+            result = source.transform_from(destination, interim)
+
+            assert np.allclose(result, vector, rtol=RTOL)
+
 
 class TestFrame2d:
     """
@@ -631,6 +695,70 @@ class TestRootFrame3d:
         assert expected5 == origin3d.find_transform_path(frame5)
         assert expected6 == origin3d.find_transform_path(frame6)
         assert expected7 == origin3d.find_transform_path(frame7)
+
+    def test_transform_from(self, frame3d_system):
+        """
+        Test the .transform_from method with random vectors and random paths.
+
+        :return: None
+        """
+        vectors = [np.random.random(3) for _ in range(10)]
+
+        for vector in vectors:
+            vector_copy = vector.copy()
+            source = frame3d_system[random.randint(0, 6)]
+            destination = origin3d
+
+            # calculate expected
+            path = source.find_transform_path(destination)
+            expected = Frame3d.transform_via_path(vector, path)
+
+            assert np.allclose(destination.transform_from(source, vector),
+                               expected, rtol=RTOL)
+
+            # Check that vector didn't change
+            assert np.allclose(vector, vector_copy, rtol=RTOL)
+
+    def test_transform_to(self, frame3d_system):
+        """
+        Test the .transform_to method with random vectors and random paths.
+
+        :return: None
+        """
+        vectors = [np.random.random(3) for _ in range(10)]
+
+        for vector in vectors:
+            vector_copy = vector.copy()
+            source = origin3d
+            destination = frame3d_system[random.randint(0, 6)]
+
+            # calculate expected
+            path = source.find_transform_path(destination)
+            expected = Frame3d.transform_via_path(vector, path)
+
+            assert np.allclose(source.transform_to(destination, vector),
+                               expected, rtol=RTOL)
+
+            # Check that vector didn't change
+            assert np.allclose(vector, vector_copy, rtol=RTOL)
+
+    def test_transform_reversible(self, frame3d_system):
+        """
+        Test wether the .transform_to and transform_from methods are
+        reversible.
+
+        :return: None
+        """
+        vectors = [np.random.random(3) for _ in range(10)]
+
+        for vector in vectors:
+            source = origin3d
+            destination = frame3d_system[random.randint(0, 6)]
+
+            interim = source.transform_to(destination, vector)
+            result = source.transform_from(destination, interim)
+
+            assert np.allclose(result, vector, rtol=RTOL)
 
 
 class TestFrame3d:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -159,6 +159,17 @@ class TestRootFrame2d:
         assert np.allclose(root_frame.position, np.array([0, 0]), rtol=RTOL)
         assert root_frame.rotation.as_rad() == 0
 
+    def test_find_common_parent(self, random_frame2d):
+        """
+        Tests the find_common_parent method. It should always return the root
+        frame itself.
+
+        :return: None
+        """
+        root_frame = RootFrame2d()
+
+        assert root_frame.find_common_parent(random_frame2d) == root_frame
+
     def test_find_transform_path(self, frame2d_system):
         """
         Test the find_transform_path method of RootFrame2d with static
@@ -242,6 +253,38 @@ class TestFrame2d:
 
         with pytest.raises(ValueError):
             frame = Frame2d(position, rot)      # noqa: F841
+
+    def test_find_common_parent(self, frame2d_system):
+        """
+        Tests the find_common_parent method.
+
+        :return: None
+        """
+        frame1 = frame2d_system[0]
+        frame2 = frame2d_system[1]
+        frame3 = frame2d_system[2]
+        frame4 = frame2d_system[3]
+        frame5 = frame2d_system[4]
+        frame6 = frame2d_system[5]
+        frame7 = frame2d_system[6]
+
+        expected0 = frame1      # frame1 and frame3
+        expected1 = frame2      # frame3 and frame7
+        expected2 = origin2d    # frame3 and frame5
+        expected3 = origin2d    # frame4 and origin2d
+        expected4 = frame2      # frame6 and frame7
+
+        result0 = frame1.find_common_parent(frame3)
+        result1 = frame3.find_common_parent(frame7)
+        result2 = frame3.find_common_parent(frame5)
+        result3 = frame4.find_common_parent(origin2d)
+        result4 = frame6.find_common_parent(frame7)
+
+        assert expected0 == result0
+        assert expected1 == result1
+        assert expected2 == result2
+        assert expected3 == result3
+        assert expected4 == result4
 
     def test_find_transform_path(self):
         """
@@ -543,6 +586,17 @@ class TestRootFrame3d:
         assert np.allclose(frame.rotation.as_matrix(), np.identity(3),
                            rtol=RTOL)
 
+    def test_find_common_parent(self, random_frame3d):
+        """
+        Tests the find_common_parent method. It should always return the root
+        frame itself.
+
+        :return: None
+        """
+        root_frame = RootFrame3d()
+
+        assert root_frame.find_common_parent(random_frame3d) == root_frame
+
     def test_find_transform_path(self, frame3d_system):
         """
         Test the find_transform_path method of RootFrame3d with static
@@ -631,6 +685,38 @@ class TestFrame3d:
 
         with pytest.raises(ValueError):
             frame = Frame3d(position, rotation)             # noqa: F841
+
+    def test_find_common_parent(self, frame3d_system):
+        """
+        Tests the find_common_parent method.
+
+        :return: None
+        """
+        frame1 = frame3d_system[0]
+        frame2 = frame3d_system[1]
+        frame3 = frame3d_system[2]
+        frame4 = frame3d_system[3]
+        frame5 = frame3d_system[4]
+        frame6 = frame3d_system[5]
+        frame7 = frame3d_system[6]
+
+        expected0 = frame1      # frame1 and frame3
+        expected1 = frame2      # frame3 and frame7
+        expected2 = origin3d    # frame3 and frame5
+        expected3 = origin3d    # frame4 and origin2d
+        expected4 = frame2      # frame6 and frame7
+
+        result0 = frame1.find_common_parent(frame3)
+        result1 = frame3.find_common_parent(frame7)
+        result2 = frame3.find_common_parent(frame5)
+        result3 = frame4.find_common_parent(origin3d)
+        result4 = frame6.find_common_parent(frame7)
+
+        assert expected0 == result0
+        assert expected1 == result1
+        assert expected2 == result2
+        assert expected3 == result3
+        assert expected4 == result4
 
     def test_find_transform_path(self):
         """

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -273,18 +273,21 @@ class TestFrame2d:
         expected2 = origin2d    # frame3 and frame5
         expected3 = origin2d    # frame4 and origin2d
         expected4 = frame2      # frame6 and frame7
+        expected5 = frame5      # frame5 and frame5
 
         result0 = frame1.find_common_parent(frame3)
         result1 = frame3.find_common_parent(frame7)
         result2 = frame3.find_common_parent(frame5)
         result3 = frame4.find_common_parent(origin2d)
         result4 = frame6.find_common_parent(frame7)
+        result5 = frame5.find_common_parent(frame5)
 
         assert expected0 == result0
         assert expected1 == result1
         assert expected2 == result2
         assert expected3 == result3
         assert expected4 == result4
+        assert expected5 == result5
 
     def test_find_transform_path(self):
         """
@@ -705,18 +708,21 @@ class TestFrame3d:
         expected2 = origin3d    # frame3 and frame5
         expected3 = origin3d    # frame4 and origin2d
         expected4 = frame2      # frame6 and frame7
+        expected5 = frame5      # frame5 and frame5
 
         result0 = frame1.find_common_parent(frame3)
         result1 = frame3.find_common_parent(frame7)
         result2 = frame3.find_common_parent(frame5)
         result3 = frame4.find_common_parent(origin3d)
         result4 = frame6.find_common_parent(frame7)
+        result5 = frame5.find_common_parent(frame5)
 
         assert expected0 == result0
         assert expected1 == result1
         assert expected2 == result2
         assert expected3 == result3
         assert expected4 == result4
+        assert expected5 == result5
 
     def test_find_transform_path(self):
         """

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -27,6 +27,7 @@ def random_frame2d():
     rotation = Rotation2d(angle)
     return Frame2d(position, rotation)
 
+
 @pytest.fixture
 def frame2d_system():
     """
@@ -60,9 +61,10 @@ class TestVector2d:
     def test_constructor(self, random_frame2d):
         """
         Test the constructor of Vector2d
+
         :return: None
         """
-        coordinates = np.random.random(3)
+        coordinates = np.random.random(2)
 
         vector = Vector2d(random_frame2d, coordinates)
 
@@ -73,16 +75,15 @@ class TestVector2d:
         """
         Test the transform_to method. This assumes, that the transform between
         Frame2d is correct.
+
         :return: None
         """
-        frameA = frame2d_system[random.randint(0, len(frame2d_system))]
-        frameB = frame2d_system[random.randint(0, len(frame2d_system))]
+        frame_a = frame2d_system[random.randint(0, len(frame2d_system) - 1)]
+        frame_b = frame2d_system[random.randint(0, len(frame2d_system) - 1)]
 
-        coordinates = np.random.random(3)
-        vector = Vector2d(frameA, coordinates)
+        coordinates = np.random.random(2)
+        vector = Vector2d(frame_a, coordinates)
 
-        expected = frameA.transform_to(frameB, coordinates)
+        expected = frame_a.transform_to(frame_b, coordinates)
 
-        assert np.allclose(vector.transform_to(frameB), expected, rtol=RTOL)
-
-
+        assert np.allclose(vector.transform_to(frame_b), expected, rtol=RTOL)

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -1,0 +1,45 @@
+"""
+Tests for the :mod:`gtFrame.vector` module.
+"""
+import math
+import random
+
+import numpy as np
+import pytest
+
+from gtFrame.basic import Frame2d
+from gtFrame.rotation import Rotation2d
+from gtFrame.vector import Vector2d
+
+RTOL = 1e-12            # relative tolerance
+
+
+@pytest.fixture
+def random_frame2d():
+    """
+    Generate a random :class:`gtFrame.basic.Frame2d.`
+
+    :return: randomly generated Frame2d
+    :rtype: gtFrame.basic.Frame2d
+    """
+    position = np.random.random(2)
+    angle = random.random() * (2 * math.pi)
+    rotation = Rotation2d(angle)
+    return Frame2d(position, rotation)
+
+
+class TestVector2d:
+    """
+    Tests for the Vector2d class.
+    """
+    def test_constructor(self, random_frame2d):
+        """
+        Test the constructor of Vector2d
+        :return: None
+        """
+        coordinates = np.random.random(3)
+
+        vector = Vector2d(random_frame2d, coordinates)
+
+        assert vector.reference == random_frame2d
+        assert np.allclose(vector.coordinates, coordinates, rtol=RTOL)

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -27,6 +27,31 @@ def random_frame2d():
     rotation = Rotation2d(angle)
     return Frame2d(position, rotation)
 
+@pytest.fixture
+def frame2d_system():
+    """
+    Generate a system of frames (Frame2d).
+
+    :return: generated system of frames as a list
+    :rtype: list
+    """
+    system = list()
+    desired_parents = ["O", 0, 1, "O", 3, 2, 1]
+
+    for parent_idx in desired_parents:
+        position = np.random.random(2)
+        angle = random.random() * (2 * math.pi)
+        rotation = Rotation2d(angle)
+
+        if parent_idx == "O":
+            frame = Frame2d(position, rotation)
+        else:
+            frame = Frame2d(position, rotation,
+                            parent_frame=system[parent_idx])
+        system.append(frame)
+
+    return system
+
 
 class TestVector2d:
     """
@@ -43,3 +68,21 @@ class TestVector2d:
 
         assert vector.reference == random_frame2d
         assert np.allclose(vector.coordinates, coordinates, rtol=RTOL)
+
+    def test_transform_to(self, frame2d_system):
+        """
+        Test the transform_to method. This assumes, that the transform between
+        Frame2d is correct.
+        :return: None
+        """
+        frameA = frame2d_system[random.randint(0, len(frame2d_system))]
+        frameB = frame2d_system[random.randint(0, len(frame2d_system))]
+
+        coordinates = np.random.random(3)
+        vector = Vector2d(frameA, coordinates)
+
+        expected = frameA.transform_to(frameB, coordinates)
+
+        assert np.allclose(vector.transform_to(frameB), expected, rtol=RTOL)
+
+


### PR DESCRIPTION
Implemented the vector.py module which allows for definitions of vectors that can automatically switch frames of reference for computation.

The module contains the following features:

Classes:

- Vector2d
- Vector3d


This pull request fixes or references the following issues:

- fixes #26 
- fixes #16

