### PR TITLE
added direction.py module

### DIFF
--- a/docs/source/module_ref.rst
+++ b/docs/source/module_ref.rst
@@ -9,5 +9,6 @@ This is a reference for all the available modules.
    :caption: Modules
 
    module_reference/basic.rst
+   module_reference/direction.rst
    module_reference/position.rst
    module_reference/rotation.rst

--- a/docs/source/module_reference/direction.rst
+++ b/docs/source/module_reference/direction.rst
@@ -1,0 +1,12 @@
+Direction
+=========
+
+Reference for the :mod:`gtFrame.direction` module.
+This module implements direction vectors which rotate with changing frames of
+reference, but are not impacted by translation of those references. This can be
+achieved with the :class:`gtFrame.direction.Direction2d` and
+:class:`gtFrame.direction.Direction3d` classes, which hold the direction
+vector as coordinates and the frame of reference on which it is defined.
+
+.. automodule:: gtFrame.direction
+    :members:

--- a/gtFrame/__init__.py
+++ b/gtFrame/__init__.py
@@ -1,2 +1,5 @@
 import pkg_resources
 __version__ = pkg_resources.get_distribution('gtFrame').version
+
+# GLOBAL DEFAULT TOLERANCE
+DEFAULT_RTOL = 1e-12

--- a/gtFrame/basic.py
+++ b/gtFrame/basic.py
@@ -225,6 +225,33 @@ class Frame2d:
         """
         return self._parent
 
+    @staticmethod
+    def rotate_via_path(vector, path):
+        """
+        This function rotates a vector according to a given transform path. The
+        function works like
+        :meth:`gtFrame.basic.Frame2d.transform_via_path`, except that it only
+        rotates the vectors and does not translate them.
+
+        :param vector: the vector to be rotated
+        :type vector: np.ndarray
+        :param path: the transform path given by
+            :meth:`gtFrame.basic.Frame2d.find_transform_path`
+        :type path: list
+        :return: the rotated vector as a numpy array
+        :rtype: np.ndarray
+        """
+        rotated = vector
+        for frame, method in path:
+            if method == "from":
+                rotated = frame.rotation.apply_inverse(rotated)
+            elif method == "to":
+                rotated = frame.rotation.apply(rotated)
+            else:
+                raise ValueError("The used method was neither 'to' nor 'from'."
+                                 " The path seems to be corrupted.")
+        return rotated
+
     def transform_from_parent(self, vector):
         """
         Transform a vector, expressed in the parent frame, into this frame.
@@ -501,6 +528,33 @@ class Frame3d:
         :rtype: Frame3d
         """
         return self._parent
+
+    @staticmethod
+    def rotate_via_path(vector, path):
+        """
+        This function rotates a vector according to a given transform path. The
+        function works like
+        :meth:`gtFrame.basic.Frame3d.transform_via_path`, except that it only
+        rotates the vectors and does not translate them.
+
+        :param vector: the vector to be rotated
+        :type vector: np.ndarray
+        :param path: the transform path given by
+            :meth:`gtFrame.basic.Frame3d.find_transform_path`
+        :type path: list
+        :return: the rotated vector as a numpy array
+        :rtype: np.ndarray
+        """
+        rotated = vector
+        for frame, method in path:
+            if method == "from":
+                rotated = frame.rotation.inv().apply(rotated)
+            elif method == "to":
+                rotated = frame.rotation.apply(rotated)
+            else:
+                raise ValueError("The used method was neither 'to' nor 'from'."
+                                 " The path seems to be corrupted.")
+        return rotated
 
     def transform_from(self, frame, vector):
         """

--- a/gtFrame/direction.py
+++ b/gtFrame/direction.py
@@ -1,0 +1,57 @@
+"""
+This module implements the Direction2d and Direction3d classe, which serve
+to represent direction-vectors (like velocity or acceleration). They hold
+information on the frame of reference in which they are defined and can be
+converted to different frames of reference by rotation. Unlike position vectors
+these vectors remain unchanged by translation.
+
+---------------
+Module Contents
+---------------
+Classes:
+    * Direction2d
+    * Direction3d
+"""
+
+
+class Direction2d:
+    """
+    This class holds information about a direction expressed as a 2d-array
+    of coordinates defined on a specific frame of reference.
+
+    :param vector: the direction expressed as a vector in the given frame of
+        reference
+    :type vector: np.ndarray
+    :param reference: the frame of reference on which the vector is defined
+    :type reference: gtFrame.basic.Frame2d
+    """
+    def __init__(self, vector, reference):
+        """
+        Constructor method.
+        """
+        if vector.shape != (2,):
+            raise ValueError("The direction vector has to be two dimensional.")
+        self.vector = vector
+        self.reference = reference
+
+
+class Direction3d:
+    """
+    This class holds information about a direction expressed as a 3d-array
+    of coordinates defined on a specific frame of reference.
+
+    :param vector: the direction expressed as a vector in the given frame of
+        reference
+    :type vector: np.ndarray
+    :param reference: the frame of reference on which the vector is defined
+    :type reference: gtFrame.basic.Frame2d
+    """
+    def __init__(self, vector, reference):
+        """
+        Constructor method.
+        """
+        if vector.shape != (3,):
+            raise ValueError("The direction vector has to be three "
+                             "dimensional.")
+        self.vector = vector
+        self.reference = reference

--- a/gtFrame/direction.py
+++ b/gtFrame/direction.py
@@ -13,6 +13,8 @@ Classes:
     * Direction3d
 """
 
+from gtFrame.basic import Frame2d, Frame3d
+
 
 class Direction2d:
     """
@@ -34,6 +36,18 @@ class Direction2d:
         self.vector = vector
         self.reference = reference
 
+    def transform_to(self, reference):
+        """
+        Transform the direction vector into another frame of reference.
+
+        :param reference: the frame of reference to transform to
+        :type reference: gtFrame.basic.Frame2d
+        :return: the direction vector in the other frame of reference
+        :rtype: np.ndarray
+        """
+        path = self.reference.find_transform_path(reference)
+        return Frame2d.rotate_via_path(self.vector, path)
+
 
 class Direction3d:
     """
@@ -44,7 +58,7 @@ class Direction3d:
         reference
     :type vector: np.ndarray
     :param reference: the frame of reference on which the vector is defined
-    :type reference: gtFrame.basic.Frame2d
+    :type reference: gtFrame.basic.Frame3d
     """
     def __init__(self, vector, reference):
         """
@@ -55,3 +69,15 @@ class Direction3d:
                              "dimensional.")
         self.vector = vector
         self.reference = reference
+
+    def transform_to(self, reference):
+        """
+        Transform the direction vector into another frame of reference.
+
+        :param reference: the frame of reference to transform to
+        :type reference: gtFrame.basic.Frame3d
+        :return: the direction vector in the other frame of reference
+        :rtype: np.ndarray
+        """
+        path = self.reference.find_transform_path(reference)
+        return Frame3d.rotate_via_path(self.vector, path)

--- a/gtFrame/direction.py
+++ b/gtFrame/direction.py
@@ -13,6 +13,9 @@ Classes:
     * Direction3d
 """
 
+import numpy as np
+
+from gtFrame import DEFAULT_RTOL
 from gtFrame.basic import Frame2d, Frame3d
 
 
@@ -26,8 +29,12 @@ class Direction2d:
     :type vector: np.ndarray
     :param reference: the frame of reference on which the vector is defined
     :type reference: gtFrame.basic.Frame2d
+    :param rtol: The relative tolerance to be used when comparing
+        Direction2d objects. The default is set to the global variable
+        DEFAULT_RTOL.
+    :type rtol: float
     """
-    def __init__(self, vector, reference):
+    def __init__(self, vector, reference, rtol=DEFAULT_RTOL):
         """
         Constructor method.
         """
@@ -35,6 +42,26 @@ class Direction2d:
             raise ValueError("The direction vector has to be two dimensional.")
         self.vector = vector
         self.reference = reference
+        self.rtol = rtol
+
+    def __eq__(self, other):
+        """
+        Compares two Direction2d objects and evaluates if they both point in
+        the same direction. Returns True if both the directions match and
+        False otherwise.
+
+        :param other: the other Direction2d object
+        :type other: gtFrame.direction.Direction2d
+        :return: returns True if the directions match within tolerance and
+            False if not
+        :rtype: bool
+        """
+        if not isinstance(other, Direction2d):
+            raise TypeError("Can only compare Direction2d to Direction2d"
+                            "objects.")
+
+        transformed = other.transform_to(self.reference)
+        return np.allclose(self.vector, transformed, rtol=self.rtol)
 
     def transform_to(self, reference):
         """
@@ -59,8 +86,12 @@ class Direction3d:
     :type vector: np.ndarray
     :param reference: the frame of reference on which the vector is defined
     :type reference: gtFrame.basic.Frame3d
+    :param rtol: The relative tolerance to be used when comparing
+        Direction3d objects. The default is set to the global variable
+        DEFAULT_RTOL.
+    :type rtol: float
     """
-    def __init__(self, vector, reference):
+    def __init__(self, vector, reference, rtol=DEFAULT_RTOL):
         """
         Constructor method.
         """
@@ -69,6 +100,26 @@ class Direction3d:
                              "dimensional.")
         self.vector = vector
         self.reference = reference
+        self.rtol = rtol
+
+    def __eq__(self, other):
+        """
+        Compares two Direction3d objects and evaluates if they both point in
+        the same direction. Returns True if both the directions match and
+        False otherwise.
+
+        :param other: the other Direction3d object
+        :type other: gtFrame.direction.Direction3d
+        :return: returns True if the directions match within tolerance and
+            False if not
+        :rtype: bool
+        """
+        if not isinstance(other, Direction3d):
+            raise TypeError("Can only compare Direction3d to Direction3d"
+                            "objects.")
+
+        transformed = other.transform_to(self.reference)
+        return np.allclose(self.vector, transformed, rtol=self.rtol)
 
     def transform_to(self, reference):
         """

--- a/gtFrame/direction.py
+++ b/gtFrame/direction.py
@@ -63,6 +63,15 @@ class Direction2d:
         transformed = other.transform_to(self.reference)
         return np.allclose(self.vector, transformed, rtol=self.rtol)
 
+    def length(self):
+        """
+        Returns the length (i.e. euclidean norm) of the direction vector.
+
+        :return: the euclidean norm of the direction vector
+        :rtype: float
+        """
+        return np.linalg.norm(self.vector)
+
     def transform_to(self, reference):
         """
         Transform the direction vector into another frame of reference.
@@ -120,6 +129,15 @@ class Direction3d:
 
         transformed = other.transform_to(self.reference)
         return np.allclose(self.vector, transformed, rtol=self.rtol)
+
+    def length(self):
+        """
+        Returns the length (i.e. euclidean norm) of the direction vector.
+
+        :return: the euclidean norm of the direction vector
+        :rtype: float
+        """
+        return np.linalg.norm(self.vector)
 
     def transform_to(self, reference):
         """

--- a/tests/test_direction.py
+++ b/tests/test_direction.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 from scipy.spatial.transform import Rotation as Rotation3d
 
+from gtFrame import DEFAULT_RTOL
 from gtFrame.basic import Frame2d, Frame3d, origin2d, origin3d
 from gtFrame.direction import Direction2d, Direction3d
 from gtFrame.rotation import Rotation2d
@@ -74,6 +75,40 @@ class TestDirection2d:
 
         with pytest.raises(ValueError):
             direction = Direction2d(vector, frame)      # noqa: F841
+
+    def test_constructor_tolerances(self):
+        """
+        Test the assignment of rtol in the constructor.
+        """
+        vector = np.random.random(2)
+        frame = random_frame2d()
+        rtol = random.random()
+
+        direction_a = Direction2d(vector, frame)
+        direction_b = Direction2d(vector, frame, rtol=rtol)
+
+        assert direction_a.rtol == DEFAULT_RTOL
+        assert direction_b.rtol == rtol
+
+    def test_eq(self):
+        """
+        Tests the .__eq__ method with random values.
+        """
+        vector = np.random.random(2)
+        last_frame = origin2d
+        direction_a = Direction2d(vector, last_frame)
+
+        for i in range(random.randint(1, 100)):
+            frame = random_frame2d(last_frame)
+            last_frame = frame
+
+            # rotate vector
+            path = direction_a.reference.find_transform_path(frame)
+            rotated = Frame2d.rotate_via_path(vector, path)
+
+            direction_b = Direction2d(rotated, frame)
+
+            assert direction_a == direction_b
 
     def test_transform_to_random(self):
         """
@@ -148,6 +183,20 @@ class TestDirection3d:
         with pytest.raises(ValueError):
             direction = Direction3d(vector, frame)      # noqa: F841
 
+    def test_constructor_tolerances(self):
+        """
+        Test the assignment of rtol in the constructor.
+        """
+        vector = np.random.random(3)
+        frame = random_frame3d()
+        rtol = random.random()
+
+        direction_a = Direction3d(vector, frame)
+        direction_b = Direction3d(vector, frame, rtol=rtol)
+
+        assert direction_a.rtol == DEFAULT_RTOL
+        assert direction_b.rtol == rtol
+
     def test_transform_to_random(self):
         """
         Tests whether the .transform_to method with random values.
@@ -164,6 +213,26 @@ class TestDirection3d:
 
         assert np.allclose(direction.transform_to(latest_frame), rotated,
                            rtol=RTOL)
+
+    def test_eq(self):
+        """
+        Tests the .__eq__ method with random values.
+        """
+        vector = np.random.random(3)
+        last_frame = origin3d
+        direction_a = Direction3d(vector, last_frame)
+
+        for i in range(random.randint(1, 100)):
+            frame = random_frame3d(last_frame)
+            last_frame = frame
+
+            # rotate vector
+            path = direction_a.reference.find_transform_path(frame)
+            rotated = Frame3d.rotate_via_path(vector, path)
+
+            direction_b = Direction3d(rotated, frame)
+
+            assert direction_a == direction_b
 
     def test_transform_to_compare(self):
         """

--- a/tests/test_direction.py
+++ b/tests/test_direction.py
@@ -1,0 +1,100 @@
+"""
+Tests for the :mod:`direction` module.
+"""
+import math
+import random
+
+import numpy as np
+import pytest
+from scipy.spatial.transform import Rotation as Rotation3d
+
+from gtFrame.basic import Frame2d, Frame3d, origin2d, origin3d
+from gtFrame.direction import Direction2d, Direction3d
+from gtFrame.rotation import Rotation2d
+
+# TOLERANCES
+RTOL = 1e-12
+
+
+def random_frame2d(parent=origin2d):
+    """
+    Generates a random Frame2d frame of reference with random values.
+
+    :param parent: the desired parent frame (default is origin2d)
+    :type parent: gtFrame.basic.Frame2d
+    :return: a randomly generated Frame2d object
+    :rtype: gtFrame.basic.Frame2d
+    """
+    rotation = Rotation2d(random.random() * 2 * math.pi)
+    position = np.random.random(2)
+    return Frame2d(position, rotation, parent_frame=parent)
+
+
+def random_frame3d(parent=origin3d):
+    """
+    Generates a random Frame3d frame of reference with random values.
+
+    :param parent: the desired parent frame (default is origin2d)
+    :type parent: gtFrame.basic.Frame3d
+    :return: a randomly generated Frame3d object
+    :rtype: gtFrame.basic.Frame3d
+    """
+    rotation = Rotation3d.from_rotvec(np.random.random(3))
+    position = np.random.random(3)
+    return Frame3d(position, rotation, parent_frame=parent)
+
+
+class TestDirection2d:
+    """
+    Holds tests for the Direction2d class.
+    """
+    def test_constructor_assign(self):
+        """
+        Tests whether the constructor assigns the correct fields.
+        """
+        vector = np.random.random(2)
+        frame = random_frame2d()
+
+        direction = Direction2d(vector, frame)
+
+        assert np.allclose(direction.vector, vector, rtol=RTOL)
+        assert direction.reference == frame
+
+    def test_constructor_exception(self):
+        """
+        Tests whether the constructor thows an exception if the wrong dim array
+        is passed.
+        """
+        vector = np.random.random(random.randint(3, 100))
+        frame = random_frame2d()
+
+        with pytest.raises(ValueError):
+            direction = Direction2d(vector, frame)      # noqa: F841
+
+
+class TestDirection3d:
+    """
+    Holds tests for the Direction3d class.
+    """
+    def test_constructor_assign(self):
+        """
+        Tests whether the constructor assigns the correct fields.
+        """
+        vector = np.random.random(3)
+        frame = random_frame3d()
+
+        direction = Direction3d(vector, frame)
+
+        assert np.allclose(direction.vector, vector, rtol=RTOL)
+        assert direction.reference == frame
+
+    def test_constructor_exception(self):
+        """
+        Tests whether the constructor thows an exception if the wrong dim array
+        is passed.
+        """
+        vector = np.random.random(random.randint(4, 100))
+        frame = random_frame3d()
+
+        with pytest.raises(ValueError):
+            direction = Direction3d(vector, frame)      # noqa: F841

--- a/tests/test_direction.py
+++ b/tests/test_direction.py
@@ -110,6 +110,18 @@ class TestDirection2d:
 
             assert direction_a == direction_b
 
+    def test_length(self):
+        """
+        Tests the .length method.
+        """
+        vector = np.random.random(2)
+        frame = random_frame2d()
+        direction = Direction2d(vector, frame)
+
+        expected = np.linalg.norm(vector)
+
+        assert direction.length() == expected
+
     def test_transform_to_random(self):
         """
         Tests whether the .transform_to method with random values.
@@ -233,6 +245,18 @@ class TestDirection3d:
             direction_b = Direction3d(rotated, frame)
 
             assert direction_a == direction_b
+
+    def test_length(self):
+        """
+        Tests the .length method.
+        """
+        vector = np.random.random(3)
+        frame = random_frame3d()
+        direction = Direction3d(vector, frame)
+
+        expected = np.linalg.norm(vector)
+
+        assert direction.length() == expected
 
     def test_transform_to_compare(self):
         """


### PR DESCRIPTION
Added the direction.py module which allows to represent directions in space, which will rotate as the frame of reference changes but will not be changed by translations.

This adds the following changes:

**direction.py**

- added Direction2d class
- added Direction3d class

**basic.py**

- added rotate_via_path method for Frame2d and Frame3d