### PR TITLE
Added scaling methods for Direction2d and Direction3d

### DIFF
--- a/gtFrame/direction.py
+++ b/gtFrame/direction.py
@@ -93,6 +93,25 @@ class Direction2d:
         """
         return np.linalg.norm(self.vector)
 
+    def scale(self, factor):
+        """
+        Scales the length of the direction vector, by multiplying it with a
+        factor.
+
+        :param factor: the factor for scaling the vector
+        :type factor: float
+        :return: None
+        """
+        try:
+            factor = float(factor)
+        except ValueError:
+            raise ValueError("A Direction2d object can only be scaled "
+                             "with a number.")
+        except TypeError:
+            raise TypeError("A Direction2d object can only be scaled "
+                            "with a number.")
+        self.vector = self.vector * factor
+
     def transform_to(self, reference):
         """
         Transform the direction vector into another frame of reference.
@@ -180,6 +199,25 @@ class Direction3d:
         :rtype: float
         """
         return np.linalg.norm(self.vector)
+
+    def scale(self, factor):
+        """
+        Scales the length of the direction vector, by multiplying it with a
+        factor.
+
+        :param factor: the factor for scaling the vector
+        :type factor: float
+        :return: None
+        """
+        try:
+            factor = float(factor)
+        except ValueError:
+            raise ValueError("A Direction3d object can only be scaled "
+                             "with a number.")
+        except TypeError:
+            raise TypeError("A Direction3d object can only be scaled "
+                            "with a number.")
+        self.vector = self.vector * factor
 
     def transform_to(self, reference):
         """

--- a/gtFrame/direction.py
+++ b/gtFrame/direction.py
@@ -63,6 +63,27 @@ class Direction2d:
         transformed = other.transform_to(self.reference)
         return np.allclose(self.vector, transformed, rtol=self.rtol)
 
+    def __mul__(self, other):
+        """
+        Scales the direction vector by an amount given by 'other' and returns
+        a new Direction2d object with the scaled vector.
+
+        :param other: the scaling factor for the direction vector
+        :type other: float
+        :return: a new Direction2d object with the scaled vector
+        :rtype: Direction2d
+        """
+        try:
+            factor = float(other)
+        except ValueError:
+            raise ValueError("A Direction2d object can only be scaled "
+                             "with a number.")
+        except TypeError:
+            raise TypeError("A Direction2d object can only be scaled "
+                            "with a number.")
+
+        return Direction2d(self.vector * factor, self.reference, self.rtol)
+
     def length(self):
         """
         Returns the length (i.e. euclidean norm) of the direction vector.
@@ -129,6 +150,27 @@ class Direction3d:
 
         transformed = other.transform_to(self.reference)
         return np.allclose(self.vector, transformed, rtol=self.rtol)
+
+    def __mul__(self, other):
+        """
+        Scales the direction vector by an amount given by 'other' and returns
+        a new Direction3d object with the scaled vector.
+
+        :param other: the scaling factor for the direction vector
+        :type other: float
+        :return: a new Direction2d object with the scaled vector
+        :rtype: Direction3d
+        """
+        try:
+            factor = float(other)
+        except ValueError:
+            raise ValueError("A Direction3d object can only be scaled "
+                             "with a number.")
+        except TypeError:
+            raise TypeError("A Direction3d object can only be scaled "
+                            "with a number.")
+
+        return Direction3d(self.vector * factor, self.reference, self.rtol)
 
     def length(self):
         """

--- a/tests/test_direction.py
+++ b/tests/test_direction.py
@@ -134,6 +134,59 @@ class TestDirection2d:
 
             assert direction_a == direction_b
 
+    def test_mul(self):
+        """
+        Tests the :meth:`gtFrame.direction.Direction2d.__mul__` method.
+        """
+        vector = np.random.random(2)
+        frame = random_frame2d()
+        r_tol = random.random()
+        direction = Direction2d(vector, frame, r_tol)
+
+        factor = random.random() * 10
+        scaled = direction * factor
+
+        assert np.allclose(scaled.vector, direction.vector * factor, rtol=RTOL)
+        assert scaled.reference == direction.reference
+        assert scaled.rtol == direction.rtol
+
+    def test_mul_int(self):
+        """
+        Tests the :meth:`gtFrame.direction.Direction2d.__mul__` method with
+        integers as factors.
+        """
+        vector = np.random.random(2)
+        frame = random_frame2d()
+        r_tol = random.random()
+        direction = Direction2d(vector, frame, r_tol)
+
+        for factor in range(ITERS):
+            scaled = direction * factor
+
+            assert np.allclose(scaled.vector, direction.vector * factor,
+                               rtol=RTOL)
+            assert scaled.reference == direction.reference
+            assert scaled.rtol == direction.rtol
+
+    def test_mul_invalid(self):
+        """
+        Tests the :meth:`gtFrame.direction.Direction2d.__mul__` method with
+        invalid values as factors.
+        """
+        inv_1 = [0.2, 2]
+        inv_2 = "hello"
+
+        vector = np.random.random(2)
+        frame = random_frame2d()
+        r_tol = random.random()
+        direction = Direction2d(vector, frame, r_tol)
+
+        with pytest.raises(TypeError):
+            direction * inv_1
+
+        with pytest.raises(ValueError):
+            direction * inv_2
+
     def test_length(self):
         """
         Tests the .length method.
@@ -293,6 +346,59 @@ class TestDirection3d:
             direction_b = Direction3d(rotated, frame)
 
             assert direction_a == direction_b
+
+    def test_mul(self):
+        """
+        Tests the :meth:`gtFrame.direction.Direction3d.__mul__` method.
+        """
+        vector = np.random.random(3)
+        frame = random_frame3d()
+        r_tol = random.random()
+        direction = Direction3d(vector, frame, r_tol)
+
+        factor = random.random() * 10
+        scaled = direction * factor
+
+        assert np.allclose(scaled.vector, direction.vector * factor, rtol=RTOL)
+        assert scaled.reference == direction.reference
+        assert scaled.rtol == direction.rtol
+
+    def test_mul_int(self):
+        """
+        Tests the :meth:`gtFrame.direction.Direction3d.__mul__` method with
+        integers as factors.
+        """
+        vector = np.random.random(3)
+        frame = random_frame3d()
+        r_tol = random.random()
+        direction = Direction3d(vector, frame, r_tol)
+
+        for factor in range(ITERS):
+            scaled = direction * factor
+
+            assert np.allclose(scaled.vector, direction.vector * factor,
+                               rtol=RTOL)
+            assert scaled.reference == direction.reference
+            assert scaled.rtol == direction.rtol
+
+    def test_mul_invalid(self):
+        """
+        Tests the :meth:`gtFrame.direction.Direction3d.__mul__` method with
+        invalid values as factors.
+        """
+        inv_1 = [0.2, 2]
+        inv_2 = "hello"
+
+        vector = np.random.random(3)
+        frame = random_frame3d()
+        r_tol = random.random()
+        direction = Direction3d(vector, frame, r_tol)
+
+        with pytest.raises(TypeError):
+            direction * inv_1
+
+        with pytest.raises(ValueError):
+            direction * inv_2
 
     def test_length(self):
         """

--- a/tests/test_direction.py
+++ b/tests/test_direction.py
@@ -1,6 +1,7 @@
 """
 Tests for the :mod:`direction` module.
 """
+import copy
 import math
 import random
 
@@ -198,6 +199,56 @@ class TestDirection2d:
         expected = np.linalg.norm(vector)
 
         assert direction.length() == expected
+
+    def test_scale(self):
+        """
+        Tests the :meth:`gtFrame.direction.Direction2d.scale` method.
+        """
+        vector = np.random.random(2)
+        frame = random_frame2d()
+        r_tol = random.random()
+        direction = Direction2d(vector, frame, r_tol)
+
+        factor = random.random() * 10
+        direction.scale(factor)
+
+        assert np.allclose(direction.vector, vector * factor, rtol=RTOL)
+
+    def test_scale_int(self):
+        """
+        Tests the :meth:`gtFrame.direction.Direction2d.scale` method with
+        integers as factors.
+        """
+        vector = np.random.random(2)
+        frame = random_frame2d()
+        r_tol = random.random()
+        direction = Direction2d(vector, frame, r_tol)
+
+        for factor in range(ITERS):
+            scaled = copy.copy(direction)
+            scaled.scale(factor)
+
+            assert np.allclose(scaled.vector, direction.vector * factor,
+                               rtol=RTOL)
+
+    def test_scale_invalid(self):
+        """
+        Tests the :meth:`gtFrame.direction.Direction2d.scale` method with
+        invalid values as factors.
+        """
+        inv_1 = [0.2, 2]
+        inv_2 = "hello"
+
+        vector = np.random.random(2)
+        frame = random_frame2d()
+        r_tol = random.random()
+        direction = Direction2d(vector, frame, r_tol)
+
+        with pytest.raises(TypeError):
+            direction.scale(inv_1)
+
+        with pytest.raises(ValueError):
+            direction.scale(inv_2)
 
     def test_transform_to_random(self):
         """
@@ -411,6 +462,56 @@ class TestDirection3d:
         expected = np.linalg.norm(vector)
 
         assert direction.length() == expected
+
+    def test_scale(self):
+        """
+        Tests the :meth:`gtFrame.direction.Direction3d.scale` method.
+        """
+        vector = np.random.random(3)
+        frame = random_frame3d()
+        r_tol = random.random()
+        direction = Direction3d(vector, frame, r_tol)
+
+        factor = random.random() * 10
+        direction.scale(factor)
+
+        assert np.allclose(direction.vector, vector * factor, rtol=RTOL)
+
+    def test_scale_int(self):
+        """
+        Tests the :meth:`gtFrame.direction.Direction3d.scale` method with
+        integers as factors.
+        """
+        vector = np.random.random(3)
+        frame = random_frame3d()
+        r_tol = random.random()
+        direction = Direction3d(vector, frame, r_tol)
+
+        for factor in range(ITERS):
+            scaled = copy.copy(direction)
+            scaled.scale(factor)
+
+            assert np.allclose(scaled.vector, direction.vector * factor,
+                               rtol=RTOL)
+
+    def test_scale_invalid(self):
+        """
+        Tests the :meth:`gtFrame.direction.Direction3d.scale` method with
+        invalid values as factors.
+        """
+        inv_1 = [0.2, 2]
+        inv_2 = "hello"
+
+        vector = np.random.random(3)
+        frame = random_frame3d()
+        r_tol = random.random()
+        direction = Direction3d(vector, frame, r_tol)
+
+        with pytest.raises(TypeError):
+            direction.scale(inv_1)
+
+        with pytest.raises(ValueError):
+            direction.scale(inv_2)
 
     def test_transform_to_compare(self):
         """


### PR DESCRIPTION
Added methods which allow scaling the vectors of Direction2d and Direction3d.

Added methods:

- `__mul__(self, other)`: scales the vector and spawns a new object with the scaled vector, but leaves self untouched
- `scale(self, factor)`: scales the vector of self object

Both methods have same implementation and functionality for Direction2d and Direction3d